### PR TITLE
Cambio de ext-net por ual-net

### DIFF
--- a/index.adoc
+++ b/index.adoc
@@ -323,7 +323,7 @@ image::AllocateFloatingIP.png[]
 El STIC tiene reservada la red 192.168.128.0/21 para OpenStack-STIC.
 ====
 
-De vuelta al formulario, se mostrará la IP flotante asignada de la red `ext-net`. Pulsar el botón `Associate`.
+De vuelta al formulario, se mostrará la IP flotante asignada de la red `ual-net`. Pulsar el botón `Associate`.
 
 image::AssignedFloatingIP.png[]
 

--- a/index.html
+++ b/index.html
@@ -1191,7 +1191,7 @@ Si más adelante necesitas crear uno o más volúmenes para tu instancia, podrá
 </table>
 </div>
 <div class="paragraph">
-<p>De vuelta al formulario, se mostrará la IP flotante asignada de la red <code>ext-net</code>. Pulsar el botón <code>Associate</code>.</p>
+<p>De vuelta al formulario, se mostrará la IP flotante asignada de la red <code>ual-net</code>. Pulsar el botón <code>Associate</code>.</p>
 </div>
 <div class="imageblock">
 <div class="content">


### PR DESCRIPTION
En el punto 4.6, se modifica el nombre de la red ext-net por ual-net